### PR TITLE
Metric Tree Shorthand (MTS) v1

### DIFF
--- a/MetricTree.js
+++ b/MetricTree.js
@@ -1,6 +1,6 @@
 class MetricTree {
     /**
-     * Takes either a nested list (a list of lists of lists of lists... etc.) and creates a MetricTree with the same topology
+     * Takes a nested list (a list of lists of lists of lists... etc.) and creates a MetricTree with the same topology
      */
     constructor(ls){
         if (typeof ls === "object"){

--- a/MetricTree.js
+++ b/MetricTree.js
@@ -1,12 +1,17 @@
 class MetricTree {
     /**
-     * Takes a nested list (a list of lists of lists of lists... etc.) and creates a MetricTree with the same topology
+     * Takes either a nested list (a list of lists of lists of lists... etc.) and creates a MetricTree with the same topology
      */
     constructor(ls){
-        this.children = []
-        ls.forEach(sublist => {
-            this.children.push(new MetricTree(sublist));
-        })
+        if (typeof ls === "object"){
+            this.children = []
+            ls.forEach(sublist => {
+                this.children.push(new MetricTree(sublist));
+            })
+        }
+        else{
+            console.error(`Argument to MetricTree constructor was an unsupported type \"${typeof ls}\" Argument in question: `, ls);
+        }
     }
 
     getDepth(){

--- a/htmlHandlers.js
+++ b/htmlHandlers.js
@@ -1,0 +1,36 @@
+const textFieldErrorColor = "#f88";
+const textFieldOkayColor = "#fff";
+
+const mtsInput = document.getElementById("mtsInput");
+const mtsErrorMessage = document.getElementById("mtsError");
+
+mtsInput.oninput = () => {
+    const s = mtsInput.value;
+
+    // remove invalid characters immediately
+    for (let i = 0; i < s.length; i++){
+        if (!(validMtsCharacters.includes(s[i]))){
+            mtsInput.value = mtsInput.value.replaceAll(s[i], "");
+        }
+    }
+    
+    mtsInput.inputIsValid = mtsStringIsValid(mtsInput.value);
+
+    mtsInput.style.backgroundColor = mtsInput.inputIsValid ? textFieldOkayColor : textFieldErrorColor;
+
+    if (mtsInput.value.length < 1 || (!mtsInput.inputIsValid)) return;
+
+    setMtsErrorMessage("");
+
+    currentPatch.tree = parseMts(mtsInput.value);
+    fullRefresh();
+}
+
+mtsInput.value = "[3,3,3,3]";
+mtsInput.style.backgroundColor = mtsStringIsValid(mtsInput.value) ? textFieldOkayColor : textFieldErrorColor;
+
+function setMtsErrorMessage(s){
+    if (!runningTests){
+        mtsErrorMessage.textContent = s;
+    }
+}

--- a/htmlHandlers.js
+++ b/htmlHandlers.js
@@ -30,7 +30,5 @@ mtsInput.value = "[3,3,3,3]";
 mtsInput.style.backgroundColor = mtsStringIsValid(mtsInput.value) ? textFieldOkayColor : textFieldErrorColor;
 
 function setMtsErrorMessage(s){
-    if (!runningTests){
-        mtsErrorMessage.textContent = s;
-    }
+    mtsErrorMessage.textContent = s;
 }

--- a/index.css
+++ b/index.css
@@ -180,3 +180,14 @@ input:checked + .slider:before {
 	color: white;
 	vertical-align: middle;
 }
+
+.meterTextInput{
+	color: black;
+	padding-bottom: 0.25rem;
+}
+
+.errorMessage{
+	font-size: 1rem;
+	color: #f88;
+	min-height: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -18,12 +18,18 @@
 			<p id="timeSigDisplay">?</p>
 		</div>
 	</div>
+	<div>
+		<input type="text" id="mtsInput" class="meterTextInput"/>
+		<p id="mtsError" class="errorMessage"></p>
+	</div>
 	<div id="p5canvas"></div>
 </div>
 <script src="MetricTree.js" defer></script>
+<script src="metricTreeShorthand.js" defer></script>
 <script src="environment.js" defer></script>
 <script src="meters.js" defer></script>
-<script src="tests.js" defer></script>
 <script src="index.js" defer></script>
+<script src="htmlHandlers.js" defer></script>
+<script src="tests.js" defer></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function setup(){
     
     if (isDevelopmentEnvironment()){
         runTests();
+        setMtsErrorMessage("");
     }
     
     fullRefresh();

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 // graphics constants
 const CANVAS_WIDTH_DEFAULT = 1200;
-const CANVAS_HEIGHT_DEFAULT = 800;
+const CANVAS_HEIGHT_DEFAULT = 700;
 let canvasWidth = CANVAS_WIDTH_DEFAULT;
 let canvasHeight = CANVAS_HEIGHT_DEFAULT;
 
@@ -38,6 +38,12 @@ function pause_(){
     noLoop();
 }
 
+function fullRefresh(){
+    refreshCanvas();
+    tree = new MetricTree(currentPatch.tree);
+    paint();
+}
+
 function refreshCanvas(){
     p5canvas = createCanvas(windowWidth, canvasHeight);
     p5canvas.parent(document.getElementById("p5canvas"));
@@ -45,15 +51,12 @@ function refreshCanvas(){
 
 function setup(){
     noLoop();
-    refreshCanvas();
-
+    
     if (isDevelopmentEnvironment()){
-        runTimeSignatureTests();
+        runTests();
     }
-
-    tree = new MetricTree(currentPatch.tree);
-
-    paint();
+    
+    fullRefresh();
 }
 
 // real mod, not javascripts default "remainder" operator %
@@ -135,8 +138,8 @@ function drawMetricTree(tree, depth){
     let leafCount = tree.getLeafNodeCount();
 
     let layerHeight = (canvasHeight - 2 * VERTICAL_PADDING) / totalDepth
-    verticalSpacing = layerHeight * 3 / 4;
     textSizeValue = min(layerHeight * 1 / 4, 1.3 * canvasWidth / leafCount);
+    verticalSpacing = (layerHeight * 3 / 4) - (textSizeValue / totalDepth);
     horizontalSpacing = (canvasWidth - 2 * HORIZONTAL_PADDING) / leafCount;
     lineThickness = max(1, textSizeValue / 15);
     

--- a/metricTreeShorthand.js
+++ b/metricTreeShorthand.js
@@ -1,0 +1,211 @@
+const validMtsCharacters = "[]*,0123456789";
+const digits = "0123456789"
+const maxActualValue = 1e4;
+
+function mtsStringProcessAsterisks(s){
+    let newString = s.slice();
+    let iterations = 0;
+    const ITERATION_LIMIT = 1000;
+    while(newString.includes("*") && iterations < ITERATION_LIMIT){
+        let multiplierStartingIndex = -1;
+        for (let i = 0; i < newString.length; i++){
+            if (newString[i] === "*"){
+                multiplierStartingIndex = i+1;
+                break;
+            }
+        }
+        let multiplierEndingIndex = -1;
+        for (let i = multiplierStartingIndex; i < newString.length + 1; i++){
+            if (!(digits.includes(newString[i]))){
+                multiplierEndingIndex = i;
+                break;
+            }
+        }
+
+        let multiplier = Number(newString.slice(multiplierStartingIndex, multiplierEndingIndex));
+
+        newString = newString.replace(`*${multiplier}`, `,{\"multiplier\":${multiplier}}`);
+        iterations += 1;
+    }
+    if (iterations >= ITERATION_LIMIT) {
+        throw new Error("Too many loops");
+    }
+    return newString;
+}
+
+function mtsStringIsValid(s){
+    if (s.length === 0) return true;
+
+    // mark invalid if any illegal characters are present
+    s.split("").forEach(c => {
+        if (!validMtsCharacters.includes(c)){
+
+            setMtsErrorMessage(`Invalid character \"${c}\"; only \"${validMtsCharacters}\" are allowed.`);
+            return false;
+        }
+    });
+
+
+    // asterisk pre-processing
+
+    // ensure any asterisks are immediately followed by a digit and nothing else
+    for (let i = 0; i < s.length - 1; i++){
+        if (s[i] === "*"){
+            if (!(digits.includes(s[i+1]))){
+                setMtsErrorMessage(`Any asterisk must be followed by a number but \"${s[i+1]}\" follows an asterisk.`);
+                return false;
+            }
+        }
+    }
+
+    // ensure any asterisks immediately follow either a digit or a closing square brace
+    for (let i = 1; i < s.length; i++){
+        if (s[i] === "*"){
+            if (!(digits.includes(s[i-1]) || s[i-1] === "]")){
+                setMtsErrorMessage(`Any asterisk must follow either a number or a closing square brace but \"${s[i+1]}\" precedes an asterisk.`);
+                return false;
+            }
+        }
+    }
+
+    try{
+        let mtsObject = JSON.parse(mtsStringProcessAsterisks(s));
+
+        if (mtsObjectContainsMultipleMultipliersInARow(mtsObject)){
+            setMtsErrorMessage("Multiple multipliers in a row are not allowed.");
+            return false;
+        }
+
+        // do recursive check
+        return mtsObjectIsValid(convertRepeatedStructureRecursive(mtsObject));
+    }
+    catch(e){
+        setMtsErrorMessage(`${e.toString().replaceAll("at line 1 column", "at index").replaceAll(" of the JSON data", "")}`);
+        return false;
+    }
+}
+
+function mtsObjectContainsMultipleMultipliersInARow(mtsObject){
+    if (typeof mtsObject === "number"){
+        return false;
+    }
+    else{
+        for (let i = 0; i < mtsObject.length; i++){
+            if (typeof mtsObject[i] === "object" &&
+                            typeof mtsObject[i].multiplier === "number" &&
+                            typeof mtsObject[i+1] === "object" &&
+                            typeof mtsObject[i+1].multiplier === "number"){
+                return true;
+            }
+        }
+
+        for (let i = 0; i < mtsObject.length; i++){
+            if (mtsObjectContainsMultipleMultipliersInARow(mtsObject[i])){
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+function mtsObjectIsValid(mtsObject){
+    if (typeof mtsObject === "number"){
+        if (mtsObject > maxActualValue){
+            setMtsErrorMessage(`Numbers bigger than ${maxActualValue} are not supported`);
+            return false;
+        }
+        return true;
+    }
+    else if (typeof mtsObject === "object"){
+        if (typeof mtsObject.length === "number"){
+            for (let i = 0; i < mtsObject.length; i++){
+                if (typeof mtsObject[i] !== typeof mtsObject[0]){
+                    setMtsErrorMessage(`All numbers must be at the same nesting level (same depth)`);
+                    return false;
+                }
+
+                if (!mtsObjectIsValid(mtsObject[i])){
+                    return false;
+                }
+            }
+
+            if (mtsObject.length < 1) {
+                setMtsErrorMessage(`All layers must be non-empty.`);
+                return false;
+            }
+
+            return true;
+        }
+        else{
+            throw new Error("Object that is neither list nor number in mtsObject");
+        }
+    }
+    else{
+        throw new Error("Unexpected type for mtsObject");
+    }
+}
+
+function deepCopy(obj){
+    return JSON.parse(JSON.stringify(obj));
+}
+
+function convertRepeatedStructureFlat(ls){
+    let newList = [];
+    for (let i = 0; i < ls.length; i++){
+        if (typeof ls[i] === "object" && typeof ls[i].multiplier === "number"){
+            for (let k = 0; k < ls[i].multiplier - 1; k++){
+                newList.push(deepCopy(ls[i-1]));
+            }
+        }
+        else{
+            newList.push(deepCopy(ls[i]));
+        }
+    }
+    
+    return newList;
+}
+
+
+/**
+ * Convert structures like [[2,3]*100003] into [[2,3],[2,3],[2,3]]
+ */
+function convertRepeatedStructureRecursive(mtsObject){
+    if (typeof mtsObject === "number"){
+        return mtsObject;
+    }
+    else if (typeof mtsObject === "object" && typeof mtsObject.length === "number"){
+        return Array.from(convertRepeatedStructureFlat(mtsObject), item => convertRepeatedStructureRecursive(item));
+    }
+    else{
+        throw new Error("Unrecognized type for mtsObject");
+    }
+}
+
+
+function parseMts(s){
+    let mtsObj = [];
+
+    if (s[0] === "[") {
+        mtsObj = JSON.parse(mtsStringProcessAsterisks(s));
+    }
+    else {
+        mtsObj = s * 1;
+    }
+
+    return convertMtsToNestedLists(convertRepeatedStructureRecursive(mtsObj));
+}
+
+
+function convertMtsToNestedLists(mtsObject){
+    if (typeof mtsObject === "number"){
+        return Array.from({length: mtsObject}, () => []);
+    }
+    
+    if (mtsObject.length > 0) {
+        return Array.from(mtsObject, item => convertMtsToNestedLists(item));
+    }
+    else{
+        console.error("something has gone wrong");
+    }
+}

--- a/tests.js
+++ b/tests.js
@@ -365,8 +365,6 @@ function runGenericTests(){
 }
 
 function runTests(){
-    runningTests = true;
     runTimeSignatureTests();
     runGenericTests();
-    runningTests = false;
 }

--- a/tests.js
+++ b/tests.js
@@ -114,7 +114,220 @@ const TIME_SIGNATURE_TESTS = [
     }
 ]
 
+GENERIC_TESTS = [
+    {
+        name: "maxActualValue is power of 10",
+        func: () => {
+            return Number(maxActualValue.toString().slice(1)) === 0;
+        }
+    },
+    {
+        name: "mtsStringIsValid empty string",
+        func: () => {
+            return mtsStringIsValid("") === true;
+        }
+    },
+    {
+        name: "mtsStringIsValid single number",
+        func: () => {
+            return mtsStringIsValid("4") === true;
+        }
+    },
+    {
+        name: "mtsStringIsValid empty list",
+        func: () => {
+            return mtsStringIsValid("[]") === false;
+        }
+    },
+    {
+        name: "mtsStringIsValid asterisk without something to multiply",
+        func: () => {
+            return mtsStringIsValid("*[2]") === false;
+        }
+    },
+    {
+        name: "mtsStringIsValid asterisk without a multiplier",
+        func: () => {
+            return mtsStringIsValid("[2*]") === false;
+        }
+    },
+    {
+        name: "mtsStringIsValid good multiplier",
+        func: () => {
+            return mtsStringIsValid("[2*3]") === true;
+        }
+    },
+    {
+        name: "mtsStringIsValid multiple multipliers",
+        func: () => {
+            return mtsStringIsValid("[2*3*3]") === false;
+        }
+    },
+    {
+        name: "mtsStringIsValid number too big",
+        func: () => {
+            return mtsStringIsValid(`[${maxActualValue+1},3]`) === false;
+        }
+    },
+    {
+        name: "mtsObjectContainsMultipleMultipliersInARow test 1",
+        func: () => {
+            return mtsObjectContainsMultipleMultipliersInARow([{multiplier:3}, {multiplier:3}]) === true;
+        }
+    },
+    {
+        name: "mtsObjectContainsMultipleMultipliersInARow test 2",
+        func: () => {
+            return mtsObjectContainsMultipleMultipliersInARow([2, {multiplier:1}]) === false;
+        }
+    },
+    {
+        name: "mtsObjectContainsMultipleMultipliersInARow test 3",
+        func: () => {
+            return mtsObjectContainsMultipleMultipliersInARow([[[2,3],{multiplier:2},[3,2]],{multiplier:3}]) === false;
+        }
+    },
+    {
+        name: "mtsObjectContainsMultipleMultipliersInARow test 4",
+        func: () => {
+            return mtsObjectContainsMultipleMultipliersInARow([[[2,3],{multiplier:2},{multiplier:7},[3,2]],{multiplier:3}]) === true;
+        }
+    },
+    {
+        name: "mtsObjectIsValid single number",
+        func: () => {
+            return mtsObjectIsValid(4) === true;
+        }
+    },
+    {
+        name: "mtsObjectIsValid empty list",
+        func: () => {
+            return mtsObjectIsValid([]) === false;
+        }
+    },
+    {
+        name: "mtsObjectIsValid nested lists",
+        func: () => {
+            return mtsObjectIsValid([[2,3],[3,4]]) === true;
+        }
+    },
+    {
+        name: "mtsObjectIsValid value too big",
+        func: () => {
+            return mtsObjectIsValid([[2,maxActualValue+1],[3,4]]) === false;
+        }
+    },
+    {
+        name: "mtsObjectIsValid value just barely small enough",
+        func: () => {
+            return mtsObjectIsValid([[2,maxActualValue-1],[3,4]]) === true;
+        }
+    },
+    {
+        name: "mtsObjectIsValid leaf nodes at different depths",
+        func: () => {
+            return mtsObjectIsValid([2,[3,4]]) === false;
+        }
+    },
+    {
+        name: "convertRepeatedStructureFlat shallow",
+        func: () => {
+            return JSON.stringify(convertRepeatedStructureFlat([3,{multiplier:3}])) === "[3,3,3]";
+        }
+    },
+    {
+        name: "convertRepeatedStructureFlat deep",
+        func: () => {
+            return JSON.stringify(convertRepeatedStructureFlat([[[3,3],[2,2,3]],{multiplier:2}])) 
+                === "[[[3,3],[2,2,3]],[[3,3],[2,2,3]]]";
+        }
+    },
+    {
+        name: "convertRepeatedStructureRecursive shallow",
+        func: () => {
+            return JSON.stringify(convertRepeatedStructureRecursive([3,{multiplier:3}])) === "[3,3,3]";
+        }
+    },
+    {
+        name: "convertRepeatedStructureRecursive deep",
+        func: () => {
+            return JSON.stringify(convertRepeatedStructureRecursive([[[3,{multiplier:2}],[5,6],{multiplier:3}],{multiplier:2}])) 
+                === "[[[3,3],[5,6],[5,6],[5,6]],[[3,3],[5,6],[5,6],[5,6]]]";
+        }
+    },
+    {
+        name: "convertMtsToNestedLists single number",
+        func: () => {
+            return JSON.stringify(convertMtsToNestedLists(2)) === "[[],[]]";
+        }
+    },
+    {
+        name: "convertMtsToNestedLists several numbers",
+        func: () => {
+            return JSON.stringify(convertMtsToNestedLists([3,4,4])) === "[[[],[],[]],[[],[],[],[]],[[],[],[],[]]]";
+        }
+    },
+    {
+        name: "convertMtsToNestedLists threshold detailed",
+        func: () => {
+            return JSON.stringify(convertMtsToNestedLists([[6,6,7],[6,6,7],[6,6,7],[6,6,7]])) === JSON.stringify(THRESHOLD_DETAILED);
+        }
+    },
+    {
+        name: "parseMts empty string",
+        func: () => {
+            return JSON.stringify(parseMts("")) === "[]";
+        }
+    },
+    {
+        name: "parseMts single number",
+        func: () => {
+            return JSON.stringify(parseMts("14")) === "[[],[],[],[],[],[],[],[],[],[],[],[],[],[]]";
+        }
+    },
+    {
+        name: "parseMts single multiplier",
+        func: () => {
+            return JSON.stringify(parseMts("[2*3]")) === "[[[],[]],[[],[]],[[],[]]]";
+        }
+    },
+    {
+        name: "parseMts two multipliers",
+        func: () => {
+            return JSON.stringify(parseMts("[2*3,3*2]")) === "[[[],[]],[[],[]],[[],[]],[[],[],[]],[[],[],[]]]";
+        }
+    },
+    {
+        name: "parseMts complex example 1",
+        func: () => {
+            return JSON.stringify(parseMts("[[2,3*2]*2,[3,2*2]*3]"))
+                === "[[[[],[]],[[],[],[]],[[],[],[]]],[[[],[]],[[],[],[]],[[],[],[]]],[[[],[],[]],[[],[]],[[],[]]],[[[],[],[]],[[],[]],[[],[]]],[[[],[],[]],[[],[]],[[],[]]]]";
+        }
+    },
+    {
+        name: "parseMts 12-bar-blues",
+        func: () => {
+            return JSON.stringify(parseMts("[[[3*4]*4]*3]")) === JSON.stringify(BLUES_12_BARS);
+        }
+    },
+    {
+        name: "GENERIC_TESTS duplicate names",
+        func: () => {
+            let dict = {};
+            GENERIC_TESTS.forEach(item => {
+                if (item.name in dict){
+                    throw new Error(`Duplicate name \"${item.name}\" in GENERIC_TESTS`)
+                }
+                dict[item.name] = true;
+            });
+
+            return true;
+        }
+    }
+]
+
 function runTimeSignatureTests(){
+    let passedCount = 0;
     TIME_SIGNATURE_TESTS.forEach(test => {
         let tree = new MetricTree(test.tree);
         let passed = tree.getTimeSignature() === test.expectedResult;
@@ -122,7 +335,38 @@ function runTimeSignatureTests(){
             console.log(`%cTest \"${test.name}\" FAILED:`, consoleErrorStyle, test);
         }
         else{
-            console.log(`%cTest \"${test.name}\" PASSED`, consoleGoodStyle)
+            passedCount += 1;
         }
     })
+    console.log(`%c${passedCount}/${TIME_SIGNATURE_TESTS.length} time signature tests passed`, consoleGoodStyle);
+}
+
+function runGenericTests(){
+    let passedCount = 0;
+    GENERIC_TESTS.forEach(test => {
+        try{
+            if (!test.func()){
+                console.log(`%cTest \"${test.name}\" FAILED:`, consoleErrorStyle, test);
+            }
+            else{
+                passedCount += 1;
+            }
+        }
+        catch(e){
+            console.error(`Test \"${test.name}\" FAILED: ${e}`);
+        }
+    });
+    if (passedCount === GENERIC_TESTS.length){
+        console.log(`%c${passedCount}/${GENERIC_TESTS.length} generic tests passed`, consoleGoodStyle);
+    }
+    else{
+        console.log(`%c${GENERIC_TESTS.length - passedCount}/${GENERIC_TESTS.length} generic tests failed`, consoleErrorStyle);
+    }
+}
+
+function runTests(){
+    runningTests = true;
+    runTimeSignatureTests();
+    runGenericTests();
+    runningTests = false;
 }


### PR DESCRIPTION
Metric Tree Shorthand (MTS) version 1 is a way of efficiently expressing metric trees with text, and this pull request introduces it to the UI of MeTr as an input method.

MTS looks like this:

`[[2,3]*2,3]`

It is similar to the nested list format but much more compact. The above MTS inflates to `[[[[],[]],[[],[],[]]],[[[],[]],[[],[],[]]],[[],[],[]]]`

33 "unit" tests are also introduced to keep tabs on everything. It may be hacky vanilla javascript but in tests we trust.

I dont really have any interfaces or any of the proper architecture in place for unit tests hence the quotes. But hey this is still loads better than no tests lol