### PR TITLE
MTS: replace commas with plus signs and remove a layer of brackets

### DIFF
--- a/MetricTree.js
+++ b/MetricTree.js
@@ -71,12 +71,16 @@ class MetricTree {
         return Array.from(this.children, t => t.getLeafNodeCountsAtDepth(depth + 1, targetDepth)).flat(1);
     }
 
-    getChildCountsAtDepth(depth, targetDepth){
+    getChildCountsAtDepth(targetDepth){
+        return this.getChildCountsAtDepthRecursive(0, targetDepth);
+    }
+
+    getChildCountsAtDepthRecursive(depth, targetDepth){
         if (depth + 1 >= targetDepth){
             return Array.from(this.children, t => t.children.length);
         }
 
-        return Array.from(this.children, t => t.getChildCountsAtDepth(depth + 1, targetDepth)).flat(1);
+        return Array.from(this.children, t => t.getChildCountsAtDepthRecursive(depth + 1, targetDepth)).flat(1);
     }
 
     largestPowerOf2ThatEvenlyDividesEverything(ls){
@@ -149,5 +153,30 @@ class MetricTree {
         }
 
         return thisDepth;
+    }
+
+    pruneLeaves(){
+        let leafParentCounts = this.getChildCountsAtDepth(this.getDepth() - 1);
+        let leafParentsAreAllOnes = true;
+        for (let lpc of leafParentCounts){
+            if (lpc !== 1){
+                leafParentsAreAllOnes = false;
+            }
+        }
+
+        if (leafParentsAreAllOnes){
+            this.removeLeaves();
+        }
+    }
+
+    /** Remove all the leaves from the tree, leaving the parents of the old leaves as the new leaves. */
+    removeLeaves(){
+        if (this.getDepth() === 1){
+            this.children = [];
+            return;
+        }
+        else{
+            this.children.forEach(c => c.removeLeaves());
+        }
     }
 }

--- a/MetricTree.js
+++ b/MetricTree.js
@@ -155,6 +155,9 @@ class MetricTree {
         return thisDepth;
     }
 
+    /** prune leaves iff all parents of leaf nodes have only one child. 
+     * This does not really affect the defined meter, but helps visually
+     * for trees representing very simple meters like 4/4 */
     pruneLeaves(){
         let leafParentCounts = this.getChildCountsAtDepth(this.getDepth() - 1);
         let leafParentsAreAllOnes = true;

--- a/htmlHandlers.js
+++ b/htmlHandlers.js
@@ -12,7 +12,8 @@ mtsInput.oninput = e => {
         for (let i = 0; i < e.data.length; i++){
             if (!(validMtsCharacters.includes(e.data[i]))){
                 mtsInput.value = mtsInputPreviousContent;
-                setMtsErrorMessage(`Input \"${e.data}\" contains invalid characters. Valid characters: \"${validMtsCharacters}\"`);
+                if (e.data !== " ")
+                    setMtsErrorMessage(`Input \"${e.data}\" contains invalid characters. Valid characters: \"${validMtsCharacters}\"`);
                 mtsInput.selectionStart = initialCursorPosition - e.data.length;
                 mtsInput.selectionEnd = initialCursorPosition - e.data.length;
                 return;

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ function fullRefresh(){
     setPatchUIElementsFromCurrentPatch();
     refreshCanvas();
     tree = new MetricTree(parseMts(currentPatch.tree));
+    tree.pruneLeaves();
     totalLeaves = tree.getLeafNodeCount();
     progressIncrement = currentPatch.leafTempo / (FRAMERATE * totalLeaves * 60);
     writePatchToUrl();

--- a/metricTreeShorthand.js
+++ b/metricTreeShorthand.js
@@ -1,10 +1,10 @@
-const validMtsCharacters = "[]*,0123456789";
+const validMtsCharacters = "[]*+0123456789";
 const digits = "0123456789"
 const maxActualValue = 1e4;
 const minActualValue = 1;
 const inconsistentDepthErrorMessage = "All numbers must be at the same nesting level (same depth)"
 
-function mtsStringProcessAsterisks(s){
+function mtsStringPreprocess(s){
     let newString = s.slice();
     let iterations = 0;
     const ITERATION_LIMIT = 1000;
@@ -32,20 +32,21 @@ function mtsStringProcessAsterisks(s){
     if (iterations >= ITERATION_LIMIT) {
         throw new Error("Too many loops");
     }
-    return newString;
+    return "[" + newString.replaceAll("+", ",") + "]";
 }
 
 function mtsStringIsValid(s){
     if (s.length === 0) return true;
 
     // mark invalid if any illegal characters are present
-    s.split("").forEach(c => {
+    let chars = s.split("")
+    for (let c of chars) {
         if (!validMtsCharacters.includes(c)){
 
             setMtsErrorMessage(`Invalid character \"${c}\"; only \"${validMtsCharacters}\" are allowed.`);
             return false;
         }
-    });
+    }
 
 
     // asterisk pre-processing
@@ -64,14 +65,14 @@ function mtsStringIsValid(s){
     for (let i = 1; i < s.length; i++){
         if (s[i] === "*"){
             if (!(digits.includes(s[i-1]) || s[i-1] === "]")){
-                setMtsErrorMessage(`Any asterisk must follow either a number or a closing square brace but \"${s[i+1]}\" precedes an asterisk.`);
+                setMtsErrorMessage(`Any asterisk must follow either a number or a closing square brace but \"${s[i-1]}\" precedes an asterisk.`);
                 return false;
             }
         }
     }
 
     try{
-        let mtsObject = JSON.parse(mtsStringProcessAsterisks(s));
+        let mtsObject = JSON.parse(mtsStringPreprocess(s));
 
         if (mtsObjectContainsMultipleMultipliersInARow(mtsObject)){
             setMtsErrorMessage("Multiple multipliers in a row are not allowed.");
@@ -212,14 +213,7 @@ function parseMts(s){
         return [];
     }
 
-    let mtsObj = [];
-
-    if (s[0] === "[") {
-        mtsObj = JSON.parse(mtsStringProcessAsterisks(s));
-    }
-    else {
-        mtsObj = s * 1;
-    }
+    let mtsObj = JSON.parse(mtsStringPreprocess(s));
 
     return convertMtsToNestedLists(applyMtsMultipliersRecursive(mtsObj));
 }

--- a/patch.js
+++ b/patch.js
@@ -10,7 +10,7 @@ const presets = [
         volumeFalloff: 0.5,
         audioSample: audioSampleOptions[0],
         numLayersMuted: 0,
-        tree: "4"
+        tree: "1*4"
     },
     {
         name: "Orange Festival (Fizz Inc.)",
@@ -23,20 +23,20 @@ const presets = [
         volumeFalloff: 0.5,
         audioSample: audioSampleOptions[0],
         numLayersMuted: 0,
-        tree: "[3,2*4]"
+        tree: "3+2*4"
     },
     {
         name: "Threshold (sungazer)",
         nodeNumberMode: "Children",
         hue: 150,
         leafTempo: 33*19,
-        accentDownbeat: true,
+        accentDownbeat: false,
         pitchesHighToLow: true,
-        pitchSpread: 1.5,
-        volumeFalloff: 0.5,
+        pitchSpread: 1.333,
+        volumeFalloff: 0.4,
         audioSample: audioSampleOptions[0],
         numLayersMuted: 0,
-        tree: "[[6,6,7]*4]"
+        tree: "[6+6+7]*4"
     },
     {
         name: "Does She Know (Andy Chamberlain)",
@@ -47,9 +47,9 @@ const presets = [
         pitchesHighToLow: true,
         pitchSpread: 1.5,
         volumeFalloff: 0.5,
-        audioSample: audioSampleOptions[2],
+        audioSample: audioSampleOptions[0],
         numLayersMuted: 0,
-        tree: "[3*7]"
+        tree: "3*7"
     },
     {
         name: "Natalie Has Never Tasted Anything Other Than Mustard (Andy Chamberlain)",
@@ -57,12 +57,12 @@ const presets = [
         hue: 60,
         leafTempo: 128*4,
         accentDownbeat: true,
-        pitchesHighToLow: true,
+        pitchesHighToLow: false,
         pitchSpread: 1.5,
         volumeFalloff: 0.5,
-        audioSample: audioSampleOptions[0],
+        audioSample: audioSampleOptions[3],
         numLayersMuted: 0,
-        tree: "[7,4]"
+        tree: "7+4"
     }
 ];
 

--- a/sound.js
+++ b/sound.js
@@ -72,7 +72,7 @@ function calculateAudioClipSpeed(leaf){
 
 function calculateAudioClipVolume(leaf){
     let soundDepth = tree.minDepthContainingNodeWhoseLeftMostLeafIsThis(leaf);
-    if (!currentPatch.accentDownbeat) soundDepth = Math.max(1, soundDepth);
+    if (!currentPatch.accentDownbeat) soundDepth = Math.max(1, soundDepth) - 1;
     return Math.pow(currentPatch.volumeFalloff, soundDepth);
 }
 

--- a/tests.js
+++ b/tests.js
@@ -326,38 +326,38 @@ const GENERIC_TESTS = [
     {
         name: "parseMts single number",
         func: () => {
-            return JSON.stringify(parseMts("14")) === "[[],[],[],[],[],[],[],[],[],[],[],[],[],[]]";
+            return JSON.stringify(parseMts("14")) === "[[[],[],[],[],[],[],[],[],[],[],[],[],[],[]]]";
         }
     },
     {
         name: "parseMts single multiplier",
         func: () => {
-            return JSON.stringify(parseMts("[2*3]")) === "[[[],[]],[[],[]],[[],[]]]";
+            return JSON.stringify(parseMts("2*3")) === "[[[],[]],[[],[]],[[],[]]]";
         }
     },
     {
         name: "parseMts two multipliers",
         func: () => {
-            return JSON.stringify(parseMts("[2*3,3*2]")) === "[[[],[]],[[],[]],[[],[]],[[],[],[]],[[],[],[]]]";
+            return JSON.stringify(parseMts("2*3+3*2")) === "[[[],[]],[[],[]],[[],[]],[[],[],[]],[[],[],[]]]";
         }
     },
     {
         name: "parseMts complex example 1",
         func: () => {
-            return JSON.stringify(parseMts("[[2,3*2]*2,[3,2*2]*3]"))
+            return JSON.stringify(parseMts("[2+3*2]*2+[3+2*2]*3"))
                 === "[[[[],[]],[[],[],[]],[[],[],[]]],[[[],[]],[[],[],[]],[[],[],[]]],[[[],[],[]],[[],[]],[[],[]]],[[[],[],[]],[[],[]],[[],[]]],[[[],[],[]],[[],[]],[[],[]]]]";
         }
     },
     {
         name: "parseMts 12-bar-blues",
         func: () => {
-            return JSON.stringify(parseMts("[[[3*4]*4]*3]")) === JSON.stringify(BLUES_12_BARS);
+            return JSON.stringify(parseMts("[[3*4]*4]*3")) === JSON.stringify(BLUES_12_BARS);
         }
     },
     {
         name: "parseMts zero multiplier",
         func: () => {
-            return JSON.stringify(parseMts("[3,2*0]")) === JSON.stringify([[[],[],[]]]);
+            return JSON.stringify(parseMts("3+2*0")) === JSON.stringify([[[],[],[]]]);
         }
     },
     {

--- a/tests.js
+++ b/tests.js
@@ -361,6 +361,21 @@ const GENERIC_TESTS = [
         }
     },
     {
+        name: "MetricTree pre-prune",
+        func: () => {
+            let t = new MetricTree(parseMts("1*4"));
+            return t.getDepth() === 2;
+        }
+    },
+    {
+        name: "MetricTree post-prune",
+        func: () => {
+            let t = new MetricTree(parseMts("1*4"));
+            t.pruneLeaves();
+            return t.getDepth() === 1;
+        }
+    },
+    {
         name: "GENERIC_TESTS duplicate names",
         func: () => {
             let dict = {};


### PR DESCRIPTION
This PR introduces some pretty significant changes to metric tree shorthand (MTS):

1. Commas are replaced with plus signs. This makes the symbols more cohesive and means evaluating the MTS as an arithmetic expression gives you the total number of subdivisions :)

2. One layer of brackets are removed. Now, the outermost square brackets are "assumed", added in before JSON parsing.

Most interesting meters that would be used with this system will be odd and compound, and previously all such cases would require a set of square brackets `[]` around the whole MTS string.

Now the interpretation is entirely consistent: the items contained in the string directly represent the real beats of a measure.

The only thing that is now more complicated in a sense is expressing simple n/4 time signatures.

The simplest MTS string for a 4/4 tree was previously `4`, but now is `1*4`. This change actually removes a special case for such trivial MTS strings, as they had to be parsed differently from ones with brackets. By default `1*4` produces a tree with a redundant layer of 1s. This does not change what time signature it evaluates to or the actual meaning of the tree, but it does come across awkward visually. For this reason I have also added a prune function to remove a redundant leaf layer of 1s when applicable.

MTS for more complex meters has been simplified, e.g.
Threshold by sungazer: `[[6,6,7]*4]` to `[6+6+7]*4`
Orange Festival by Fizz Inc.: `[3,2*4]` to `3+2*4`
Does She Know breakdown: `[7*3]` to `7*3`