### PR TITLE
37 multiple tempo modes

### DIFF
--- a/htmlHandlers.js
+++ b/htmlHandlers.js
@@ -1,6 +1,11 @@
 const textFieldErrorColor = "#f88";
 const textFieldOkayColor = "#fff";
 
+
+//////////////////
+//  MTS INPUT   //
+//////////////////
+
 const mtsInput = document.getElementById("mtsInput");
 const mtsErrorMessage = document.getElementById("mtsError");
 
@@ -48,53 +53,50 @@ function setMtsErrorMessage(s){
     mtsErrorMessage.textContent = s;
 }
 
-const volumeIcon = document.getElementById("volumeIcon");
-const globalVolumeSlider = document.getElementById("globalVolumeSlider");
-globalVolumeSlider.oninput = () => {
-    if (globalVolumeSlider.valueAsNumber > 50){
-        volumeIcon.src = "assets/images/volume_high_white.png";
+
+
+///////////////////////
+//  Preset Selection //
+///////////////////////
+
+const presetSelectDropdown = document.getElementById("presetSelectDropdown");
+
+presetSelectDropdown.oninput = () => {
+    for (let i = 0; i < presets.length; i++){
+        if (presets[i].name === presetSelectDropdown.children[presetSelectDropdown.selectedIndex].value){
+            currentPatch = deepCopy(presets[i]);
+            mtsInputPreviousContent = currentPatch.tree;
+            fullRefresh();
+            break;
+        }
     }
-    else if (globalVolumeSlider.valueAsNumber > 0){
-        volumeIcon.src = "assets/images/volume_low_white.png";
+
+    trySelectPreset();
+}
+
+function populatepresetSelectDropdown(){
+    presetSelectDropdown.replaceChildren([]);
+    for (let preset of presets){
+        let elem = document.createElement("option");
+        elem.value = preset.name;
+        elem.text = preset.name;
+
+        presetSelectDropdown.appendChild(elem);
     }
-    else{
-        volumeIcon.src = "assets/images/volume_off_white.png";
+}
+
+populatepresetSelectDropdown();
+
+
+function setPresetDisplayNames(){
+    for (let i = 0; i < presetSelectDropdown.children.length; i++){
+        if (i === presetSelectDropdown.selectedIndex){
+            presetSelectDropdown.children[i].text = "*" + presets[i].name;
+        }
+        else{
+            presetSelectDropdown.children[i].text = presets[i].name;
+        }
     }
-    doVolumeInput();
-}
-
-const logb = (base, x) => {
-    return Math.log(x) / Math.log(base);
-}
-
-function convertSliderValueToAmplitude(sliderVal) {
-    // use exponential scale to go from 0 to 1 so the volume slider feels more natural
-    const tension = 10; // how extreme the curve is (higher = more extreme, slower start faster end)
-    const n = 1 / (1 - logb(1 / tension, 1 + (1 / tension)));         
-    const val = Math.pow(1 / tension, 1 - ((sliderVal * 1.25) / 100) / n) - 1 / tension;
-    return val;
-}
-
-function doVolumeInput() {
-    const val = convertSliderValueToAmplitude(globalVolumeSlider.valueAsNumber);
-    globalVolume = val;
-}
-
-
-const playPauseBtn = document.getElementById("playPauseBtn");
-const playPauseBtnIcon = document.getElementById("playPauseBtnIcon");
-const resetBtn = document.getElementById("resetBtn");
-
-playPauseBtn.onclick = () => {
-    playPauseBtn.blur();
-    playPause();
-}
-
-resetBtn.onclick = () => {
-    resetBtn.blur();
-    pause_();
-    globalProgress = 0;
-    fullRefresh();
 }
 
 
@@ -113,38 +115,6 @@ function setTempoInputFromCurrentPatch(){
     tempoInput.value = currentPatch.leafTempo;
 }
 
-
-/////////////////////////////////
-//  NODE NUMBER MODE SETTING   //
-/////////////////////////////////
-
-const nodeNumberModeLeaves = document.getElementById("nodeNumberModeLeaves");
-const nodeNumberModeChildren = document.getElementById("nodeNumberModeChildren");
-
-nodeNumberModeLeaves.onclick = () => {
-    nodeNumberModeLeaves.className = "nodeNumberModeOption nodeNumberModeOptionSelected";
-    nodeNumberModeChildren.className = "nodeNumberModeOption";
-    setPatchParam("nodeNumberMode", "Leaves");
-    if(p5canvas)
-        paint();
-}
-
-nodeNumberModeChildren.onclick = () => {
-    nodeNumberModeChildren.className = "nodeNumberModeOption nodeNumberModeOptionSelected";
-    nodeNumberModeLeaves.className = "nodeNumberModeOption";
-    setPatchParam("nodeNumberMode", "Children");
-    if (p5canvas)
-        paint();
-}
-
-function setNumberModeInputFromCurrentPatch(){
-    if (currentPatch.nodeNumberMode === "Leaves"){
-        nodeNumberModeLeaves.onclick();
-    }
-    else{
-        nodeNumberModeChildren.onclick();
-    }
-}
 
 
 /////////////////////////////
@@ -206,6 +176,40 @@ function setClickSoundSettingsFromCurrentPatch(){
 
 
 
+/////////////////////////////////
+//  NODE NUMBER MODE SETTING   //
+/////////////////////////////////
+
+const nodeNumberModeLeaves = document.getElementById("nodeNumberModeLeaves");
+const nodeNumberModeChildren = document.getElementById("nodeNumberModeChildren");
+
+nodeNumberModeLeaves.onclick = () => {
+    nodeNumberModeLeaves.className = "nodeNumberModeOption nodeNumberModeOptionSelected";
+    nodeNumberModeChildren.className = "nodeNumberModeOption";
+    setPatchParam("nodeNumberMode", "Leaves");
+    if(p5canvas)
+        paint();
+}
+
+nodeNumberModeChildren.onclick = () => {
+    nodeNumberModeChildren.className = "nodeNumberModeOption nodeNumberModeOptionSelected";
+    nodeNumberModeLeaves.className = "nodeNumberModeOption";
+    setPatchParam("nodeNumberMode", "Children");
+    if (p5canvas)
+        paint();
+}
+
+function setNumberModeInputFromCurrentPatch(){
+    if (currentPatch.nodeNumberMode === "Leaves"){
+        nodeNumberModeLeaves.onclick();
+    }
+    else{
+        nodeNumberModeChildren.onclick();
+    }
+}
+
+
+
 //////////////
 //  COLOR   //
 //////////////
@@ -251,50 +255,64 @@ function changeHue(e){
 
 
 
+/////////////////////////
+//  PLAYBACK CONTROLS  //
+/////////////////////////
 
-///////////////////////
-//  Preset Selection //
-///////////////////////
-
-const presetSelectDropdown = document.getElementById("presetSelectDropdown");
-
-presetSelectDropdown.oninput = () => {
-    for (let i = 0; i < presets.length; i++){
-        if (presets[i].name === presetSelectDropdown.children[presetSelectDropdown.selectedIndex].value){
-            currentPatch = deepCopy(presets[i]);
-            mtsInputPreviousContent = currentPatch.tree;
-            fullRefresh();
-            break;
-        }
+const volumeIcon = document.getElementById("volumeIcon");
+const globalVolumeSlider = document.getElementById("globalVolumeSlider");
+globalVolumeSlider.oninput = () => {
+    if (globalVolumeSlider.valueAsNumber > 50){
+        volumeIcon.src = "assets/images/volume_high_white.png";
     }
-
-    trySelectPreset();
+    else if (globalVolumeSlider.valueAsNumber > 0){
+        volumeIcon.src = "assets/images/volume_low_white.png";
+    }
+    else{
+        volumeIcon.src = "assets/images/volume_off_white.png";
+    }
+    doVolumeInput();
 }
 
-function populatepresetSelectDropdown(){
-    presetSelectDropdown.replaceChildren([]);
-    for (let preset of presets){
-        let elem = document.createElement("option");
-        elem.value = preset.name;
-        elem.text = preset.name;
-
-        presetSelectDropdown.appendChild(elem);
-    }
+const logb = (base, x) => {
+    return Math.log(x) / Math.log(base);
 }
 
-populatepresetSelectDropdown();
-
-
-function setPresetDisplayNames(){
-    for (let i = 0; i < presetSelectDropdown.children.length; i++){
-        if (i === presetSelectDropdown.selectedIndex){
-            presetSelectDropdown.children[i].text = "*" + presets[i].name;
-        }
-        else{
-            presetSelectDropdown.children[i].text = presets[i].name;
-        }
-    }
+function convertSliderValueToAmplitude(sliderVal) {
+    // use exponential scale to go from 0 to 1 so the volume slider feels more natural
+    const tension = 10; // how extreme the curve is (higher = more extreme, slower start faster end)
+    const n = 1 / (1 - logb(1 / tension, 1 + (1 / tension)));         
+    const val = Math.pow(1 / tension, 1 - ((sliderVal * 1.25) / 100) / n) - 1 / tension;
+    return val;
 }
+
+function doVolumeInput() {
+    const val = convertSliderValueToAmplitude(globalVolumeSlider.valueAsNumber);
+    globalVolume = val;
+}
+
+
+const playPauseBtn = document.getElementById("playPauseBtn");
+const playPauseBtnIcon = document.getElementById("playPauseBtnIcon");
+const resetBtn = document.getElementById("resetBtn");
+
+playPauseBtn.onclick = () => {
+    playPauseBtn.blur();
+    playPause();
+}
+
+resetBtn.onclick = () => {
+    resetBtn.blur();
+    pause_();
+    globalProgress = 0;
+    fullRefresh();
+}
+
+
+
+/////////////////////////
+//  SET EVERYTHING UP  //
+/////////////////////////
 
 function setPatchUIElementsFromCurrentPatch(){
     setClickSoundSettingsFromCurrentPatch();

--- a/htmlHandlers.js
+++ b/htmlHandlers.js
@@ -2,13 +2,13 @@ const textFieldErrorColor = "#f88";
 const textFieldOkayColor = "#fff";
 
 
+
 //////////////////
 //  MTS INPUT   //
 //////////////////
 
 const mtsInput = document.getElementById("mtsInput");
 const mtsErrorMessage = document.getElementById("mtsError");
-
 
 mtsInput.oninput = e => {
     // remove invalid characters immediately
@@ -36,18 +36,18 @@ mtsInput.oninput = e => {
     
     setMtsErrorMessage("");
     
-    setPatchParam("tree", mtsInput.value);
+    setPatchParam("mts", mtsInput.value);
+    setLeafTempoBasedOnDisplayTempo();
     if (p5canvas){
         fullRefresh();
     }
 }
 
-let mtsInputPreviousContent = currentPatch.tree;
+let mtsInputPreviousContent = currentPatch.mts;
 
 function setMtsInputFromCurrentPatch(){
-    mtsInput.value = currentPatch.tree;
+    mtsInput.value = currentPatch.mts;
 }
-
 
 function setMtsErrorMessage(s){
     mtsErrorMessage.textContent = s;
@@ -65,8 +65,9 @@ presetSelectDropdown.oninput = () => {
     for (let i = 0; i < presets.length; i++){
         if (presets[i].name === presetSelectDropdown.children[presetSelectDropdown.selectedIndex].value){
             currentPatch = deepCopy(presets[i]);
-            mtsInputPreviousContent = currentPatch.tree;
+            mtsInputPreviousContent = currentPatch.mts;
             fullRefresh();
+            setPatchUIElementsFromCurrentPatch();
             break;
         }
     }
@@ -87,7 +88,6 @@ function populatepresetSelectDropdown(){
 
 populatepresetSelectDropdown();
 
-
 function setPresetDisplayNames(){
     for (let i = 0; i < presetSelectDropdown.children.length; i++){
         if (i === presetSelectDropdown.selectedIndex){
@@ -107,15 +107,79 @@ function setPresetDisplayNames(){
 
 const tempoInput = document.getElementById("tempoInput");
 tempoInput.oninput = () => {
-    setPatchParam("leafTempo", tempoInput.valueAsNumber);
+    setPatchParam("leafTempo", calculateLeafTempo(tempoInput.valueAsNumber));
     fullRefresh();
 }
 
-function setTempoInputFromCurrentPatch(){
-    tempoInput.value = currentPatch.leafTempo;
+const displayTempoDropdown = document.getElementById("displayTempoDropdown");
+for (let option of displayTempoOptions){
+    let elem = document.createElement('option');
+    elem.value = option;
+    elem.innerText = option;
+    displayTempoDropdown.appendChild(elem);
 }
 
+function setLeafTempoBasedOnDisplayTempo(){
+    setPatchParam("leafTempo", calculateLeafTempo(tempoInput.valueAsNumber));
+}
 
+displayTempoDropdown.oninput = () => {
+    setPatchParam("displayTempoMode", displayTempoOptions[displayTempoDropdown.selectedIndex]);
+    fullRefresh();
+}
+
+function calculateLeafTempo(displayTempoValue){
+    const tree = new MetricTree(parseMts(currentPatch.mts));
+    const leafCounts = tree.getChildrensLeafNodeCounts();
+    if (currentPatch.displayTempoMode === "Largest Beat"){
+        let maxBeatSize = 0;
+        for (let count of leafCounts){
+            maxBeatSize = Math.max(maxBeatSize, count);
+        }
+        return displayTempoValue * maxBeatSize;
+    }
+    else if (currentPatch.displayTempoMode === "Smallest Beat"){
+        let minBeatSize = Infinity;
+        for (let count of leafCounts){
+            minBeatSize = Math.min(minBeatSize, count);
+        }
+        return displayTempoValue * minBeatSize;
+    }
+    else{
+        return displayTempoValue;
+    }
+}
+
+function calculateDisplayTempo(){
+    const tree = new MetricTree(parseMts(currentPatch.mts));
+    const leafCounts = tree.getChildrensLeafNodeCounts();
+    if (currentPatch.displayTempoMode === "Largest Beat"){
+        let maxBeatSize = 0;
+        for (let count of leafCounts){
+            maxBeatSize = Math.max(maxBeatSize, count);
+        }
+        return (currentPatch.leafTempo / maxBeatSize);
+    }
+    else if (currentPatch.displayTempoMode === "Smallest Beat"){
+        let minBeatSize = Infinity;
+        for (let count of leafCounts){
+            minBeatSize = Math.min(minBeatSize, count);
+        }
+        return currentPatch.leafTempo / minBeatSize;
+    }
+    else{
+        return currentPatch.leafTempo;
+    }
+}
+
+function setTempoInputFromCurrentPatch(){
+    console.log("hello there", calculateDisplayTempo());
+    tempoInput.value = calculateDisplayTempo();
+}
+
+function setTempoDisplayModeFromCurrentPatch(){
+    displayTempoDropdown.selectedIndex = displayTempoOptions.indexOf(currentPatch.displayTempoMode);
+}
 
 /////////////////////////////
 //  CLICK SOUND SETTINGS   //
@@ -320,6 +384,7 @@ function setPatchUIElementsFromCurrentPatch(){
     setMtsInputFromCurrentPatch();
     setNumberModeInputFromCurrentPatch();
     setTempoInputFromCurrentPatch();
+    setTempoDisplayModeFromCurrentPatch();
     setPresetDisplayNames();
     trySelectPreset();
 }

--- a/index.css
+++ b/index.css
@@ -97,6 +97,7 @@ a:active {
 	background-color: #111;
 	color: white;
 	border: none;
+	border-radius: 4px;
 }
 
 input[type="number"]{
@@ -122,9 +123,20 @@ input[type="checkbox"]{
 }
 
 .patchBigNumber{
-	width: 70%;
+	width: 100%;
 	height: 3rem;
 	font-size: 2.5rem;
+	border-radius: 4px;
+}
+
+#tempoInput{
+	border-bottom-left-radius: 0px;
+	border-bottom-right-radius: 0px;
+}
+
+#displayTempoDropdown{
+	border-top-left-radius: 0px;
+	border-top-right-radius: 0px;
 }
 
 .patchSmallNumber{

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 				<label for="tempoInput" id="tempoInputLabel" class="settingsCategoryLabel">Tempo</label>
 				<br/>
 				<input type="number" id="tempoInput" class="patchBigNumber" />
+				<select id="displayTempoDropdown"  class="patchDropdown"></select>
 			</div>
 			<div class="settingsCategory">
 				<div class="patchSettingRow">
@@ -61,7 +62,7 @@
 			<div class="appDrawerDivider"></div>
 			<br/>
 			<div class="settingsCategory">
-				<label for="nodeNumberModeDropdown" id="nodeNumberModeDropdownLabel" class="settingsCategoryLabel">Node Numbers</label>
+				<label id="nodeNumberModeDropdownLabel" class="settingsCategoryLabel">Node Numbers</label>
 				<div id="nodeNumberModeSelectorContainer">
 					<div class="nodeNumberModeOption" id="nodeNumberModeLeaves" style="flex: 1;">
 						Leaves

--- a/index.js
+++ b/index.js
@@ -82,6 +82,11 @@ function setup(){
     globalVolumeSlider.oninput();
 
     setInterval(writePatchToUrl, 100);
+
+    window.addEventListener("popstate", () => {
+        setPatchFromURL();
+        fullRefresh();
+    });
     
     if (isDevelopmentEnvironment()){
         runTests();

--- a/index.js
+++ b/index.js
@@ -59,9 +59,8 @@ function pause_(){
 
 function fullRefresh(){
     setMtsErrorMessage("");
-    setPatchUIElementsFromCurrentPatch();
     refreshCanvas();
-    tree = new MetricTree(parseMts(currentPatch.tree));
+    tree = new MetricTree(parseMts(currentPatch.mts));
     tree.pruneLeaves();
     totalLeaves = tree.getLeafNodeCount();
     progressIncrement = currentPatch.leafTempo / (FRAMERATE * totalLeaves * 60);

--- a/patch.js
+++ b/patch.js
@@ -1,33 +1,46 @@
+const nodeNumberModeOptions = [
+    "Leaves",
+    "Children"
+];
+
+const displayTempoOptions = [
+    "Leaves",
+    "Smallest Beat",
+    "Largest Beat"
+];
+
 const presets = [
     {
         name: "Default",
-        nodeNumberMode: "Leaves",
+        nodeNumberMode: nodeNumberModeOptions[0],
         hue: 300,
         leafTempo: 120,
         accentDownbeat: true,
         pitchesHighToLow: true,
         pitchSpread: 1.5,
         volumeFalloff: 0.5,
-        audioSample: audioSampleOptions[4],
+        audioSample: audioSampleOptions[1],
         numLayersMuted: 0,
-        tree: "1*4"
+        mts: "1*4",
+        displayTempoMode: displayTempoOptions[0]
     },
     {
         name: "Orange Festival (Fizz Inc.)",
-        nodeNumberMode: "Leaves",
+        nodeNumberMode: nodeNumberModeOptions[0],
         hue: 30,
-        leafTempo: 320,
+        leafTempo: 160*2,
         accentDownbeat: true,
         pitchesHighToLow: true,
         pitchSpread: 1.5,
         volumeFalloff: 0.5,
         audioSample: audioSampleOptions[0],
         numLayersMuted: 0,
-        tree: "3+2*4"
+        mts: "3+2*4",
+        displayTempoMode: displayTempoOptions[0]
     },
     {
         name: "Threshold (sungazer)",
-        nodeNumberMode: "Children",
+        nodeNumberMode: nodeNumberModeOptions[1],
         hue: 150,
         leafTempo: 33*19,
         accentDownbeat: false,
@@ -36,24 +49,26 @@ const presets = [
         volumeFalloff: 0.5,
         audioSample: audioSampleOptions[3],
         numLayersMuted: 0,
-        tree: "[6+6+7]*4"
+        mts: "[6+6+7]*4",
+        displayTempoMode: displayTempoOptions[1]
     },
     {
         name: "Does She Know (Andy Chamberlain)",
-        nodeNumberMode: "Children",
+        nodeNumberMode: nodeNumberModeOptions[1],
         hue: 300,
         leafTempo: 165*3,
         accentDownbeat: true,
         pitchesHighToLow: true,
         pitchSpread: 1.5,
         volumeFalloff: 0.5,
-        audioSample: audioSampleOptions[1],
+        audioSample: audioSampleOptions[4],
         numLayersMuted: 0,
-        tree: "3*7"
+        mts: "3*7",
+        displayTempoMode: displayTempoOptions[2]
     },
     {
         name: "Natalie Has Never Tasted Anything Other Than Mustard (Andy Chamberlain)",
-        nodeNumberMode: "Leaves",
+        nodeNumberMode: nodeNumberModeOptions[0],
         hue: 60,
         leafTempo: 128*4,
         accentDownbeat: true,
@@ -62,14 +77,10 @@ const presets = [
         volumeFalloff: 0.5,
         audioSample: audioSampleOptions[2],
         numLayersMuted: 0,
-        tree: "7+4"
+        mts: "7+4",
+        displayTempoMode: displayTempoOptions[0]
     }
 ];
-
-const nodeNumberModeOptions = [
-    "Leaves",
-    "Children"
-]
 
 const musicSensitiveParams = ["leafTempo", "tree", "numLayersMuted"];
 
@@ -78,56 +89,61 @@ let currentPatch = deepCopy(presets[0]);
 const patchParams = [
     {
         name: "nodeNumberMode",
-        compress: (x) => nodeNumberModeOptions.indexOf(x),
-        decompress: (x) => nodeNumberModeOptions[x]
+        compress: x => nodeNumberModeOptions.indexOf(x),
+        decompress: x => nodeNumberModeOptions[x]
     },
     {
         name: "hue",
-        compress: (x) => x,
-        decompress: (x) => x
+        compress: x => x,
+        decompress: x => x
     },
     {
         name: "leafTempo",
-        compress: (x) => x,
-        decompress: (x) => x,
+        compress: x => x,
+        decompress: x => x,
         musical: true
     },
     {
         name: "accentDownbeat",
-        compress: (x) => x ? 1 : 0,
-        decompress: (x) => !!x
+        compress: x => x ? 1 : 0,
+        decompress: x => !!x
     },
     {
         name: "pitchesHighToLow",
-        compress: (x) => x ? 1 : 0,
-        decompress: (x) => !!x
+        compress: x => x ? 1 : 0,
+        decompress: x => !!x
     },
     {
         name: "pitchSpread",
-        compress: (x) => x,
-        decompress: (x) => x
+        compress: x => x,
+        decompress: x => x
     },
     {
         name: "volumeFalloff",
-        compress: (x) => x,
-        decompress: (x) => x
+        compress: x => x,
+        decompress: x => x
     },
     {
         name: "audioSample",
-        compress: (x) => Array.from(audioSampleOptions, o => o.filename).indexOf(x.filename),
-        decompress: (x) => audioSampleOptions[x]
+        compress: x => Array.from(audioSampleOptions, o => o.filename).indexOf(x.filename),
+        decompress: x => audioSampleOptions[x]
     },
     {
         name: "numLayersMuted",
-        compress: (x) => x,
-        decompress: (x) => x,
+        compress: x => x,
+        decompress: x => x,
         musical: true
     },
     {
-        name: "tree",
-        compress: (x) => x,
-        decompress: (x) => x,
+        name: "mts",
+        compress: x => x,
+        decompress: x => x,
         musical: true
+    },
+    {
+        name: "displayTempoMode",
+        compress: x => displayTempoOptions.indexOf(x),
+        decompress: x => displayTempoOptions[x]
     }
 ]
 
@@ -220,7 +236,7 @@ function trySelectPreset(){
     }
 
     for (let i = 0; i < presets.length; i++){
-        if (currentPatch.tree === presets[i].tree && currentPatch.leafTempo === presets[i].leafTempo){
+        if (currentPatch.mts === presets[i].tree && currentPatch.leafTempo === presets[i].leafTempo){
             presetSelectDropdown.children[i].text = "*" + presets[i].name;
             presetSelectDropdown.selectedIndex = i;
             return;


### PR DESCRIPTION
Introduce tempo modes.

Before, the patch simply had an attribute called `leafTempo`. `leafTempo` remains, but an additional attribute `displayTempoMode` is introduced.

This allows you to set the tempo in the UI according to either leaves, the smallest beat, or the larget beat. This is very helpful if you want to experiment with different subdivisions at the same tempo.

Under the hood, `leafTempo` is still the only thing used; the display/input for the tempo just gets converted appropriately.